### PR TITLE
GenerateQuizScreen now fetches tokens from API

### DIFF
--- a/projekti/frontend/pages/GenerateQuizScreen.js
+++ b/projekti/frontend/pages/GenerateQuizScreen.js
@@ -1,8 +1,17 @@
 import React, { useState, useEffect } from "react";
-import { View, Text, StyleSheet, Button, Alert } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+  TouchableOpacity,
+  Switch,
+  Modal,
+  StatusBar,
+} from "react-native";
 import Slider from "@react-native-community/slider";
 import { Picker } from "@react-native-picker/picker";
-import { TouchableOpacity } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export default function GenerateQuizScreen({ navigation }) {
   const [categories, setCategories] = useState([]);
@@ -10,19 +19,10 @@ export default function GenerateQuizScreen({ navigation }) {
   const [category, setCategory] = useState("");
   const [difficulty, setDifficulty] = useState("");
   const [type, setType] = useState("");
-
-  const apiUrl = "https://opentdb.com/api.php";
-
-  const generateQueryUrl = () => {
-    const queryParams = [`amount=${amountOfQuestions}`];
-
-    if (category) queryParams.push(`category=${category}`);
-    if (difficulty) queryParams.push(`difficulty=${difficulty}`);
-    if (type) queryParams.push(`type=${type}`);
-
-    const queryUrl = `${apiUrl}?${queryParams.join("&")}`;
-    return queryUrl;
-  };
+  const [apiSessionToken, setApiSessionToken] = useState("");
+  const [useToken, setUseToken] = useState(false);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const [isTokenEmpty, setIsTokenEmpty] = useState(false);
 
   const fetchCategories = async () => {
     try {
@@ -32,6 +32,75 @@ export default function GenerateQuizScreen({ navigation }) {
     } catch (error) {
       console.error("Error fetching categories:", error);
     }
+  };
+
+  const fetchApiSessionToken = async () => {
+    try {
+      const response = await fetch(
+        "https://opentdb.com/api_token.php?command=request"
+      );
+      const data = await response.json();
+      if (data.response_code === 0) {
+        return data.token;
+      } else {
+        console.error(
+          `Error fetching token: ${data.response_message}. Error code: ${data.response_code}`
+        );
+        Alert.alert(
+          `Error fetching token: ${data.response_message}. Error code: ${data.response_code}`
+        );
+      }
+    } catch (err) {
+      console.error(`Unexpected error: ${err}`);
+      Alert.alert(`Unexpected error: ${err}`);
+    }
+  };
+
+  const resetApiSessionToken = async () => {
+    try {
+      const response = await fetch(
+        `https://opentdb.com/api_token.php?command=reset&token=${apiSessionToken}`
+      );
+      const data = await response.json();
+      if (data.response_code === 0) {
+        Alert.alert("Reset successful!");
+        hideTokenEmpty()
+      } else {
+        Alert.alert("Error. Something went wrong while resetting the token");
+      }
+    } catch (err) {
+      console.error(`Error resetting token: ${err}`);
+    }
+  };
+
+  const getApiSessionToken = async () => {
+    try {
+      const existingToken = await AsyncStorage.getItem("API-Token");
+      if (existingToken !== null) {
+        setApiSessionToken(existingToken);
+      } else {
+        const token = await fetchApiSessionToken();
+        await AsyncStorage.setItem("API-Token", token);
+        setApiSessionToken(token);
+      }
+    } catch (err) {
+      console.error(`Unexpected error: ${err}`);
+      Alert.alert(`Unexpected error: ${err}`);
+    }
+  };
+
+  const generateQueryUrl = () => {
+    const apiUrl = "https://opentdb.com/api.php";
+    const queryParams = [`amount=${amountOfQuestions}`];
+
+    if (category) queryParams.push(`category=${category}`);
+    if (difficulty) queryParams.push(`difficulty=${difficulty}`);
+    if (type) queryParams.push(`type=${type}`);
+    if (apiSessionToken && useToken)
+      queryParams.push(`token=${apiSessionToken}`);
+
+    const queryUrl = `${apiUrl}?${queryParams.join("&")}`;
+    return queryUrl;
   };
 
   const fetchQuestions = async () => {
@@ -49,6 +118,8 @@ export default function GenerateQuizScreen({ navigation }) {
     const data = await fetchQuestions();
     if (data.response_code === 0) {
       navigation.navigate("Game", { questions: data.results });
+    } else if (data.response_code === 4) {
+      showTokenEmpty()
     } else {
       let errorMessage = "";
 
@@ -64,10 +135,6 @@ export default function GenerateQuizScreen({ navigation }) {
         case 3:
           errorMessage = "Token Not Found: Session Token does not exist.";
           break;
-        case 4:
-          errorMessage =
-            "Token Empty: Session Token has returned all possible questions for the specified query. You may need to reset the Token.";
-          break;
         case 5:
           errorMessage =
             "Rate Limit Exceeded: Too many requests. Each IP can only access the API once every 5 seconds.";
@@ -81,11 +148,85 @@ export default function GenerateQuizScreen({ navigation }) {
 
   useEffect(() => {
     fetchCategories();
+    getApiSessionToken();
   }, []);
+
+  const showInfo = () => {
+    setIsInfoOpen(true);
+    StatusBar.setBackgroundColor("rgba(0, 0, 0, 0.7)");
+  };
+  const hideInfo = () => {
+    setIsInfoOpen(false);
+    StatusBar.setBackgroundColor("#FFF");
+  };
+
+  const showTokenEmpty = () => {
+    setIsTokenEmpty(true)
+    StatusBar.setBackgroundColor("#rgba(0, 0, 0, 0.7)");
+  }
+  const hideTokenEmpty = () => {
+    setIsTokenEmpty(false)
+    StatusBar.setBackgroundColor("#FFF");
+  }
 
   return (
     <View style={styles.page}>
-      <Text style={styles.header}>Select quiz options</Text>
+      <Modal
+        visible={isInfoOpen}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={hideInfo}
+      >
+        <View style={styles.modalFull}>
+          <View style={styles.modalContainer}>
+            <Text style={{ fontSize: 16 }}>
+              When the switch is toggled on, the app will make sure that you are
+              not asked the same questions multiple times, even if you close the
+              app and come back!
+            </Text>
+            <View>
+              <Text style={{ marginBottom: 8, fontSize: 16 }}>
+                This is a manual reset button. If you click this you may get the
+                same questions again. Automatic resets happen after 6 hours of
+                inactivity. If the app detects it has ran out of questions to
+                ask you based on the options you provided you will be asked if
+                you want to reset.
+              </Text>
+              <TouchableOpacity
+                style={styles.resetButton}
+                onPress={resetApiSessionToken}
+              >
+                <Text style={{ color: "#FFF" }}>RESET</Text>
+              </TouchableOpacity>
+            </View>
+            <TouchableOpacity style={styles.closeInfoButton} onPress={hideInfo}>
+              <Text style={{ color: "#FFF" }}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        visible={isTokenEmpty}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={hideTokenEmpty}
+      >
+        <View style={styles.modalFull}>
+          <View style={[styles.modalContainer, {height:"40%"}]}>
+            <Text style={{fontSize:16, marginBottom:8}}>
+              The app has ran out of new questions to ask you with these specific options.
+              Would you like to reset your token?
+            </Text>
+            <TouchableOpacity style={styles.resetButton} onPress={resetApiSessionToken}>
+              <Text style={{color:"#FFF"}}>RESET</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.closeInfoButton} onPress={hideTokenEmpty}>
+              <Text style={{color:"#FFF"}}>Close</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
 
       <Text style={styles.genericLabel}>Number of questions</Text>
       <View style={styles.sliderContainer}>
@@ -98,8 +239,8 @@ export default function GenerateQuizScreen({ navigation }) {
           value={amountOfQuestions}
           onValueChange={(value) => setAmountOfQuestions(value)}
           minimumTrackTintColor="#001011ff"
-          maximumTrackTintColor="#444"
-          thumbTintColor="#19DFE6ff"
+          maximumTrackTintColor="#666"
+          thumbTintColor="#444"
         />
       </View>
 
@@ -148,11 +289,27 @@ export default function GenerateQuizScreen({ navigation }) {
         <Picker.Item label="True / False" value={"boolean"} />
       </Picker>
 
-      <View style={styles.buttonContainer}>
-        <TouchableOpacity style={styles.startButton} onPress={() => generateQuiz()}>
-          <Text style={styles.buttonText}>Start Quiz</Text>
+      <View style={{ display: "flex", flexDirection: "row" }}>
+        <Text style={styles.genericLabel}>Avoid asking same questions? </Text>
+        <TouchableOpacity onPress={showInfo}>
+          <Text style={{ fontStyle: "italic" }}>ⓘ</Text>
         </TouchableOpacity>
       </View>
+
+      <Switch
+        style={{ margin: 0 }}
+        trackColor={{ false: "red", true: "green" }}
+        value={useToken}
+        onValueChange={() => setUseToken((prev) => !prev)}
+      ></Switch>
+
+      <Text>{generateQueryUrl()}</Text>
+      <TouchableOpacity
+        style={styles.startButton}
+        onPress={() => generateQuiz()}
+      >
+        <Text style={styles.buttonText}>Start Quiz</Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -166,13 +323,41 @@ const styles = StyleSheet.create({
     padding: 24,
     backgroundColor: "#EEE",
   },
+  modalFull: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 32,
+    backgroundColor: "rgba(0, 0, 0, 0.7)",
+  },
+  modalContainer: {
+    width: "100%",
+    height: "70%",
+    padding: 16,
+    backgroundColor: "#FFF",
+    borderRadius: 32,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  resetButton: {
+    backgroundColor: "#666",
+    paddingVertical: 8,
+    paddingHorizontal: 32,
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 16,
+  },
+  closeInfoButton: {
+    backgroundColor: "#000",
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 16,
+  },
   genericLabel: {
     marginBottom: 8,
-    color: "#001011ff"
-  },
-  header: {
-    fontSize: 24,
-    marginBottom: 24,
+    color: "#001011ff",
   },
   sliderContainer: {
     display: "flex",
@@ -200,14 +385,6 @@ const styles = StyleSheet.create({
     marginTop: 20,
     fontSize: 18,
   },
-  buttonContainer: {
-    flex: 1,
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 20,
-  },
   startButton: {
     paddingVertical: 18,
     paddingHorizontal: 38,
@@ -220,5 +397,5 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "500",
     color: "#FFF",
-  }
+  },
 });

--- a/projekti/package-lock.json
+++ b/projekti/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~3.2.3",
+        "@react-native-async-storage/async-storage": "^1.24.0",
         "@react-native-community/slider": "4.5.2",
         "@react-native-picker/picker": "2.7.5",
         "@react-navigation/drawer": "^6.7.2",
@@ -3811,6 +3812,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
     },
     "node_modules/@react-native-community/cli": {
       "version": "13.6.9",
@@ -8789,6 +8802,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -10043,6 +10065,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
       "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/projekti/package.json
+++ b/projekti/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.2.3",
+    "@react-native-async-storage/async-storage": "^1.24.0",
     "@react-native-community/slider": "4.5.2",
     "@react-native-picker/picker": "2.7.5",
     "@react-navigation/drawer": "^6.7.2",


### PR DESCRIPTION
Token is fetched from API to ensure user is not asked same question multiple times. Token is resettable via a button in the info modal. User can opt out of using token entirely via a simple switch. User is notified if their quiz generation failed because the API no longer has enough new questions to satisfy the query and user is asked if they would like to reset the token. Token is also saved in AsyncStorage to persist in memory through app reloads.