### PR TITLE
Dark mode and GenerateQuizScreen improvements.

### DIFF
--- a/projekti/frontend/components/CustomPicker.js
+++ b/projekti/frontend/components/CustomPicker.js
@@ -1,0 +1,208 @@
+import React, { useState, useEffect } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  Modal,
+  FlatList,
+  StyleSheet,
+  Dimensions,
+} from "react-native";
+import Icon from "react-native-vector-icons/Entypo";
+
+const { width } = Dimensions.get("window");
+
+/**
+ * CustomPicker component renders a custom picker modal where users can select an item from a list.
+ *
+ * @component
+ * @example
+ * const items = [
+ *   { label: 'Item 1', value: '1' },
+ *   { label: 'Item 2', value: '2' },
+ * ];
+ *
+ * const { isDarkMode } = useContext(DarkModeContext);
+ * 
+ * const [selectedValue, setSelectedValue] = useState("")
+ *
+ * <CustomPicker
+ *   items={items}
+ *   selectedValue={selectedValue}
+ *   onSelect={(value) => setSelectedValue(value)}
+ *   styles={[pickerStyles, isDarkMode ? darkPickerStyles : {}]}
+ *   iconColor={isDarkMode ? "white" : "black"}
+ * />
+ *
+ * const pickerStyles = StyleSheet.create({
+ *   itemText: {
+ *     color: "black", // make item text color black by default
+ *   },
+ * })
+ * const darkPickerStyles = StyleSheet.create({
+ *   itemText: {
+ *     color: "white" // if dark mode make item text color white
+ *   }
+ * })
+ *
+ *
+ * @param {Object[]} items - Array of items to display in the picker. Each item should have `label` and `value` properties.
+ * @param {string} selectedValue - The value of the currently selected item. It should match the `value` of one of the items in the `items` array.
+ * @param {function} onSelect - Callback function that is called when an item is selected. Receives the selected value as its argument.
+ * @param {Object} [styles] - Optional styles for customizing the picker. It should be an array of `StyleSheet` objects. A single object can be passed, but must still be in an array. The following classes are available:
+ *   - `item`: Style for each picker item (Touchable Opacity)
+ *   - `itemText`: Style for the text inside each picker item
+ *   - `button`: Style for the button that opens the picker (Touchable Opacity)
+ *   - `buttonText`: Style for the text inside the picker opening button
+ *   - `modalOverlay`: Style for the overlay behind the modal
+ *   - `modalContent`: Style for the modal content
+ *   - `flatList`: Style for the FlatList container
+ * @param {string} iconColor - Color of the chevron-down icon in the picker button. Optional. Defaults to black if omitted. Should be a string (e.g. "#000" or "black")
+ *
+ * @returns {JSX.Element} - A picker component with a button to open the modal and select an item.
+ */
+
+const CustomPicker = ({
+  items,
+  selectedValue,
+  onSelect,
+  styles = [],
+  iconColor = "black",
+}) => {
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selected, setSelected] = useState(
+    selectedValue || (items && items[0]?.value)
+  );
+
+  useEffect(() => {
+    if (!selectedValue && items.length > 0) {
+      setSelected(items[0].value);
+    }
+  }, [selectedValue, items]);
+
+  const selectedLabel = items.find((item) => item.value === selected)?.label;
+
+  const handleSelect = (value) => {
+    setSelected(value);
+    onSelect(value);
+    setModalVisible(false);
+  };
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity
+      style={[
+        defaultStyles.item,
+        styles.map((item) => (item?.item ? item.item : {})),
+      ]}
+      onPress={() => handleSelect(item.value)}
+    >
+      <Text
+        style={[
+          defaultStyles.itemText,
+          styles.map((item) => (item?.itemText ? item.itemText : {})),
+        ]}
+      >
+        {item.label}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View>
+      <TouchableOpacity
+        style={[
+          defaultStyles.button,
+          styles.map((item) => (item?.button ? item.button : {})),
+        ]}
+        onPress={() => setModalVisible(true)}
+      >
+        <Text
+          style={[
+            defaultStyles.buttonText,
+            styles.map((item) => (item?.buttonText ? item.buttonText : {})),
+          ]}
+          numberOfLines={1}
+          ellipsizeMode="tail"
+        >
+          {selectedLabel || items[0]?.label}
+        </Text>
+        <Icon name="chevron-thin-down" size={20} color={iconColor} />
+      </TouchableOpacity>
+
+      <Modal
+        visible={modalVisible}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={() => setModalVisible(false)}
+      >
+        <TouchableOpacity
+          style={[
+            defaultStyles.modalOverlay,
+            styles.map((item) => (item?.modalOverlay ? item.modalOverlay : {})),
+          ]}
+          onPress={() => setModalVisible(false)}
+        >
+          <View
+            style={[
+              defaultStyles.modalContent,
+              styles.map((item) =>
+                item?.modalContent ? item.modalContent : {}
+              ),
+            ]}
+          >
+            <FlatList
+              data={items}
+              keyExtractor={(item) => item.value.toString()}
+              renderItem={renderItem}
+              style={[
+                defaultStyles.flatList,
+                styles.map((item) => (item?.flatList ? item.flatList : {})),
+              ]}
+            />
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </View>
+  );
+};
+
+const defaultStyles = StyleSheet.create({
+  button: {
+    width: width - 40,
+    paddingVertical: 16,
+    paddingHorizontal: 24,
+    backgroundColor: "#FFF",
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "start",
+    borderRadius: 32,
+  },
+  buttonText: {
+    fontSize: 16,
+    color: "black",
+    maxWidth: "80%",
+  },
+  modalOverlay: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  modalContent: {
+    maxHeight: "80%",
+    width: width - 40,
+    backgroundColor: "white",
+    borderRadius: 24,
+    overflow: "hidden",
+  },
+  item: {
+    padding: 16,
+  },
+  itemText: {
+    fontSize: 16,
+    color: "black",
+  },
+});
+
+export default CustomPicker;

--- a/projekti/frontend/components/DrawerNavigator.js
+++ b/projekti/frontend/components/DrawerNavigator.js
@@ -6,22 +6,26 @@ import AboutScreen from "../pages/AboutScreen";
 import HowToPlayScreen from "../pages/HowToPlayScreen";
 import DarkMode from "../pages/DarkMode";
 import { DarkModeContext } from '../pages/DarkModeContext';
+import { StatusBar } from 'react-native';
 
 const Drawer = createDrawerNavigator();
 
 export default function DrawerNavigator() {
   const { isDarkMode } = useContext(DarkModeContext);
 
-  const drawerStyles = isDarkMode ? darkDrawerStyles : lightDrawerStyles;
+  const styles = isDarkMode ? darkStyles : lightStyles;
 
   return (
     <Drawer.Navigator
       initialRouteName="Home"
       screenOptions={{
         headerTitleAlign: "center",
-        drawerInactiveTintColor: drawerStyles.inactiveTintColor,
-        drawerActiveTintColor: drawerStyles.activeTintColor,
-        drawerStyle: drawerStyles.drawerStyle,
+        swipeEnabled: false, // Disables drawer opening by swiping, only opens on burger menu icon press
+        drawerInactiveTintColor: styles.inactiveTintColor,
+        drawerActiveTintColor: styles.activeTintColor,
+        drawerStyle: styles.drawerStyle,
+        headerStyle: styles.headerStyle,
+        headerTintColor: styles.headerTintColor
       }}
     >
       <Drawer.Screen name="Home" component={HomeScreen} />
@@ -33,18 +37,30 @@ export default function DrawerNavigator() {
   );
 }
 
-const lightDrawerStyles = {
+const lightStyles = {
   inactiveTintColor: "#001011ff",
   activeTintColor: "#001011ff",
   drawerStyle: {
     backgroundColor: '#fff',
   },
+  headerStyle: {
+    backgroundColor: "#FFF",
+    elevation: 20,
+    shadowColor: "#f87609",
+  },
+  headerTintColor: "#000",
 };
 
-const darkDrawerStyles = {
+const darkStyles = {
   inactiveTintColor: "#ffffff",
   activeTintColor: "#ffffff",
   drawerStyle: {
     backgroundColor: '#121212',
   },
+  headerStyle: {
+    backgroundColor: "#000",
+    elevation: 20,
+    shadowColor: "#f87609",
+  },
+  headerTintColor: "#FFF",
 };

--- a/projekti/frontend/components/StackNavigator.js
+++ b/projekti/frontend/components/StackNavigator.js
@@ -1,21 +1,29 @@
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import DrawerNavigator from './DrawerNavigator';
-import GameScreen from '../pages/GameScreen';
-import KahootHomeScreen from '../pages/CustomQuizPages/KahootHomeScreen';
-import LoginScreen from '../pages/LoginScreen';
-import Lobby from '../pages/CustomQuizPages/Lobby';
-import SelectQuiz from '../pages/CustomQuizPages/SelectQuiz';
-import KahootGameScreen from '../pages/CustomQuizPages/KahootGameScreen';
-import QuizzScreen from '../pages/CustomQuizPages/QuizzScreen';
-import CreateQuiz from '../pages/CustomQuizPages/CreateQuiz';
-import SignUpScreen from '../pages/SignUpScreen';
-import GenerateQuizKahoot from '../pages/CustomQuizPages/GenerateQuizKahoot';
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import DrawerNavigator from "./DrawerNavigator";
+import GameScreen from "../pages/GameScreen";
+import KahootHomeScreen from "../pages/CustomQuizPages/KahootHomeScreen";
+import LoginScreen from "../pages/LoginScreen";
+import Lobby from "../pages/CustomQuizPages/Lobby";
+import SelectQuiz from "../pages/CustomQuizPages/SelectQuiz";
+import KahootGameScreen from "../pages/CustomQuizPages/KahootGameScreen";
+import QuizzScreen from "../pages/CustomQuizPages/QuizzScreen";
+import CreateQuiz from "../pages/CustomQuizPages/CreateQuiz";
+import SignUpScreen from "../pages/SignUpScreen";
+import GenerateQuizKahoot from "../pages/CustomQuizPages/GenerateQuizKahoot";
+import { StatusBar } from 'react-native';
+import { DarkModeContext } from "../pages/DarkModeContext";
+import { useContext } from "react";
 
-const Stack = createNativeStackNavigator()
+const Stack = createNativeStackNavigator();
 
 // Place any screens you want to only be accessible through the use of navigation.navigate here
 export default function StackNavigator() {
+  const { isDarkMode } = useContext(DarkModeContext);
+  const styles = isDarkMode ? darkStyles : lightStyles;
+
   return (
+    <>
+    <StatusBar barStyle={styles.barStyle} backgroundColor={styles.backgroundColor}/>
     <Stack.Navigator screenOptions={{ headerTitleAlign: 'center' }}>
       <Stack.Screen
         name="Main"
@@ -29,11 +37,30 @@ export default function StackNavigator() {
       <Stack.Screen name="Login" component={LoginScreen} />
       <Stack.Screen name="Lobby" component={Lobby} />
       <Stack.Screen name="SelectQuiz" component={SelectQuiz} />
-      <Stack.Screen name="KahootGameScreen" component={KahootGameScreen} options={{headerLeft: null}} />
-      <Stack.Screen name="QuizzScreen" component={QuizzScreen} options={{headerLeft: null}} />
+      <Stack.Screen
+        name="KahootGameScreen"
+        component={KahootGameScreen}
+        options={{ headerLeft: null }}
+      />
+      <Stack.Screen
+        name="QuizzScreen"
+        component={QuizzScreen}
+        options={{ headerLeft: null }}
+      />
       <Stack.Screen name="CreateQuiz" component={CreateQuiz} />
       <Stack.Screen name="SignUpScreen" component={SignUpScreen} />
       <Stack.Screen name="GenerateQuizKahoot" component={GenerateQuizKahoot} />
     </Stack.Navigator>
-  )
+    </>
+  );
+}
+
+const lightStyles = {
+  barStyle: "dark-content",
+  backgroundColor: "#FFF"
+}
+
+const darkStyles = {
+  barStyle: "light-content",
+  backgroundColor: "#000"
 }


### PR DESCRIPTION
Added dark mode to header and StatusBar. Greatly improved the looks of GenerateQuizScreen and made a few tweaks, such as removing the manual reset button, opting to only pop up a reset button if the token actually runs out of questions. API session token is now always used and the switch to turn off the token has been removed to streamline the user experience. Added a completely custom picker element CustomPicker, which has neat features and a decent JSDoc documentation to help other team members understand how it is used (you can see this documentation by hovering over the component in VS Code after importing the component and placing it in code)