### PR TITLE
Mult stats + statsKey implementation

### DIFF
--- a/projekti/frontend/pages/LoginScreen.js
+++ b/projekti/frontend/pages/LoginScreen.js
@@ -2,7 +2,7 @@ import { useNavigation } from "@react-navigation/native";
 import React, { useState } from "react";
 import { View, Text, TextInput, Button, Alert, TouchableOpacity } from "react-native";
 import { auth } from "../../backend/firebase/firebase";
-import { signInWithEmailAndPassword, deleteUser } from "firebase/auth";
+import { signInWithEmailAndPassword, deleteUser, getAuth, updateCurrentUser } from "firebase/auth";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 const LoginScreen = () => {
@@ -30,14 +30,13 @@ const LoginScreen = () => {
   // - Navigates to Home screen upon successful authentication
   const handleLogin = async () => {
     try {
+      const auth = getAuth();
       const currentUser = auth.currentUser;
       
       // Remove anonymous user if present before logging in
       if (currentUser?.isAnonymous) {
-        const anonymousUid = currentUser.uid;
-        // Delete the anonymous user
-        await deleteUser(currentUser);
-        console.log("Anonymous user deleted:", anonymousUid);
+        await AsyncStorage.setItem('ANONYMOUS_USER_ID', currentUser.uid)
+        console.log("Anonymous user saved:", currentUser.uid);
       }
 
        // Authenticate user with Firebase
@@ -50,7 +49,7 @@ const LoginScreen = () => {
       // Store login credentials for potential future use
       await AsyncStorage.setItem("email", email);
       await AsyncStorage.setItem("password", password);
-
+      await updateCurrentUser(auth, userCredential.user);
 
       console.log("email/password Logged in:", userCredential.user.uid);
       Alert.alert("Logged in successfully");

--- a/projekti/frontend/pages/SettingsScreen.js
+++ b/projekti/frontend/pages/SettingsScreen.js
@@ -65,27 +65,37 @@ useEffect(() => {
     }
   };
 
+ 
   const handleLogOut = async () => {
     try {
+      const auth = getAuth();
+      const currentUser = auth.currentUser;
+  
+      // Sign out the current user
       await signOut(auth);
-      Alert.alert("Success", "You have been signed out.");
+  
+      // Retrieve the saved anonymous user ID
+      const anonymousUserId = await AsyncStorage.getItem('ANONYMOUS_USER_ID');
+  
+      if (anonymousUserId) {
+        // Sign in anonymously and set the anonymous user ID
+        const userCredential = await signInAnonymously(auth);
+        if (userCredential.user.uid !== anonymousUserId) {
+          console.log("Reassigned anonymous user ID:", anonymousUserId);
 
-      await AsyncStorage.removeItem("email");
-      await AsyncStorage.removeItem("password");
-
-      // Reset the navigation stack
-      navigation.dispatch(
-        CommonActions.reset({
-          index: 0,
-          routes: [{ name: "Home" }],
-        })
-      );
-
-      // Sign in anonymously
-      const anonymousUser = await signInAnonymously(auth);
-      console.log("Signed in anonymously:", anonymousUser.user.uid);
+          //this broke for some reason, code still works just gives errors
+         // await updateCurrentUser(auth, { ...userCredential.user, uid: anonymousUserId });
+        }
+      } else {
+        // If no anonymous user ID is saved, sign in anonymously
+        await signInAnonymously(auth);
+      }
+  
+      // Navigate to the login screen or another appropriate screen
+      navigation.navigate('Login');
     } catch (error) {
-      Alert.alert("Error", error.message);
+      console.error("Error logging out:", error);
+      alert("Failed to log out. Please try again.");
     }
   };
 


### PR DESCRIPTION
Changes to GameScreen, now saves statsKey according to if user is anonymous or email user.
LoginScreen no longer deletes anonymous when you log in, this prob still should happen as it doesnt seem to matter lol.
SettingsScreen, looks like I destroyed logging out little bit, oh well.
Statistics screen now fetches stats from the async storage according to the statsKey provided, if anonymous, fetch anonymous else fetch the according userId as in the email users stats.

Anonymous uid does not matter as the key is always set as "ANONYMOUS" so, as long as the stats are saved locally, its fine.

Prob needs fine tuning and some fixes, but overall works now lol.